### PR TITLE
Add README with setup instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 !backend/**
 !frontend/
 !frontend/**
+!README.md
 !/*.pptx
 
 # Python junk anywhere

--- a/README.md
+++ b/README.md
@@ -1,0 +1,48 @@
+# HUJI Hackathon 2025 Backend
+
+People that coded this repo: [NathanP23](https://github.com/NathanP23)
+
+The git history of this repository only lists a single author. No other contributors were found in the repository.
+
+## Prerequisites
+
+- Python 3.10+
+- Node.js 18+
+
+## Backend Setup
+
+1. Install Python dependencies:
+   ```bash
+   pip install openai google-generativeai anthropic python-dotenv aiohttp python-socketio
+   ```
+2. Create a `.env` file at the repository root with your API keys:
+   ```env
+   OPENAI_API_KEY=<your OpenAI key>
+   GEMINI_API_KEY=<your Gemini key>
+   ANTHROPIC_API_KEY=<your Anthropic key>
+   ```
+3. Start the backend server:
+   ```bash
+   python backend/Main.py
+   ```
+   This runs an aiohttp + Socket.IO server on port `4000`.
+
+## Frontend Setup
+
+1. Install Node dependencies:
+   ```bash
+   cd frontend
+   npm install
+   ```
+2. Start the React development server:
+   ```bash
+   npm start
+   ```
+   The app will open on `http://localhost:3000` and connect to the backend at `http://localhost:4000`.
+
+## Project Structure
+
+- `backend/` – Python server and LLM utilities.
+- `frontend/` – React client application.
+- `מצגת האקתון.pptx` – Presentation from the hackathon.
+


### PR DESCRIPTION
## Summary
- add project setup instructions in README
- whitelist README in `.gitignore`

## Testing
- `npm test --silent --yes` *(fails: react-scripts 403 Forbidden)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684078ed0a0483228b157d2811cfdb6f